### PR TITLE
Add ArchUnit tests verifying that Hexagonal Architecture is being followed

### DIFF
--- a/.run/Unit Tests.run.xml
+++ b/.run/Unit Tests.run.xml
@@ -5,7 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="tags" />
-    <tag value="!manual &amp; !integration &amp; !mvc" />
+    <tag value="!manual &amp; !integration &amp; !mvc &amp; !architecture" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
       <artifactId>annotations</artifactId>
       <version>${jetbrains.annotations.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <version>0.22.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- https://mvnrepository.com/artifact/net.sourceforge.htmlunit/htmlunit -->
     <dependency>

--- a/src/test/java/com/jitterted/mobreg/HexArchTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexArchTest.java
@@ -1,0 +1,36 @@
+package com.jitterted.mobreg;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+public class HexArchTest {
+    @Test
+    public void domainMustNotDependOnAdapters() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..adapter..")
+                .check(productionAndTestClasses());
+    }
+
+    @Test
+    public void domainMustNotDependOnApplication() {
+        noClasses()
+                .that().resideInAPackage("..domain..")
+                .should().dependOnClassesThat().resideInAPackage("..application..")
+                .check(productionClasses());
+    }
+
+    private JavaClasses productionAndTestClasses() {
+        return new ClassFileImporter().importPackages("com.jitterted.mobreg");
+    }
+
+    private JavaClasses productionClasses() {
+        return new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.jitterted.mobreg");
+    }
+}

--- a/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
@@ -6,6 +6,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 public class HexagonalArchitectureTest {
     @Test
@@ -22,6 +23,14 @@ public class HexagonalArchitectureTest {
                 .that().resideInAPackage("..domain..")
                 .should().dependOnClassesThat().resideInAPackage("..application..")
                 .check(productionClasses());
+    }
+
+    @Test
+    public void adaptersMustNotDependOnEachOther() {
+       slices().matching("..adapter.*.(*)..")
+               .should().notDependOnEachOther()
+               .as("Adapters must not depend on each other")
+               .check(productionAndTestClasses());
     }
 
     private JavaClasses productionAndTestClasses() {

--- a/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
@@ -26,6 +26,14 @@ public class HexagonalArchitectureTest {
     }
 
     @Test
+    public void applicationMustNotDependOnAdapters() {
+        noClasses()
+                .that().resideInAPackage("..application..")
+                .should().dependOnClassesThat().resideInAPackage("..adapter..")
+                .check(productionAndTestClasses());
+    }
+
+    @Test
     public void adaptersMustNotDependOnEachOther() {
        slices().matching("..adapter.*.(*)..")
                .should().notDependOnEachOther()

--- a/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
@@ -3,11 +3,13 @@ package com.jitterted.mobreg;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
+@Tag("architecture")
 public class HexagonalArchitectureTest {
     @Test
     public void domainMustNotDependOnAdapters() {

--- a/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
@@ -21,6 +21,9 @@ public class HexagonalArchitectureTest {
 
     @Test
     public void domainMustNotDependOnApplication() {
+        // SMELL: Some test classes in the domain package depend on test classes
+        //   in the adapter package (e.g. TestMemberBuilder). Until they are
+        //   split or moved appropriately this test will only check productionClasses().
         noClasses()
                 .that().resideInAPackage("..domain..")
                 .should().dependOnClassesThat().resideInAPackage("..application..")

--- a/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
+++ b/src/test/java/com/jitterted/mobreg/HexagonalArchitectureTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
-public class HexArchTest {
+public class HexagonalArchitectureTest {
     @Test
     public void domainMustNotDependOnAdapters() {
         noClasses()

--- a/src/test/java/com/jitterted/mobreg/adapter/in/web/member/MemberControllerTest.java
+++ b/src/test/java/com/jitterted/mobreg/adapter/in/web/member/MemberControllerTest.java
@@ -4,6 +4,7 @@ import com.jitterted.mobreg.application.EnsembleService;
 import com.jitterted.mobreg.application.EnsembleServiceFactory;
 import com.jitterted.mobreg.application.MemberFactory;
 import com.jitterted.mobreg.application.MemberService;
+import com.jitterted.mobreg.application.port.DummyNotifier;
 import com.jitterted.mobreg.application.port.DummyVideoConferenceScheduler;
 import com.jitterted.mobreg.application.port.InMemoryEnsembleRepository;
 import com.jitterted.mobreg.application.port.InMemoryMemberRepository;

--- a/src/test/java/com/jitterted/mobreg/application/EnsembleServiceEditExistingTest.java
+++ b/src/test/java/com/jitterted/mobreg/application/EnsembleServiceEditExistingTest.java
@@ -1,6 +1,6 @@
 package com.jitterted.mobreg.application;
 
-import com.jitterted.mobreg.adapter.in.web.member.DummyNotifier;
+import com.jitterted.mobreg.application.port.DummyNotifier;
 import com.jitterted.mobreg.application.port.ConferenceDetails;
 import com.jitterted.mobreg.application.port.InMemoryEnsembleRepository;
 import com.jitterted.mobreg.application.port.InMemoryMemberRepository;

--- a/src/test/java/com/jitterted/mobreg/application/EnsembleServiceFactory.java
+++ b/src/test/java/com/jitterted/mobreg/application/EnsembleServiceFactory.java
@@ -1,6 +1,6 @@
 package com.jitterted.mobreg.application;
 
-import com.jitterted.mobreg.adapter.in.web.member.DummyNotifier;
+import com.jitterted.mobreg.application.port.DummyNotifier;
 import com.jitterted.mobreg.application.port.DummyVideoConferenceScheduler;
 import com.jitterted.mobreg.application.port.EnsembleRepository;
 import com.jitterted.mobreg.application.port.InMemoryEnsembleRepository;

--- a/src/test/java/com/jitterted/mobreg/application/port/DummyNotifier.java
+++ b/src/test/java/com/jitterted/mobreg/application/port/DummyNotifier.java
@@ -1,6 +1,5 @@
-package com.jitterted.mobreg.adapter.in.web.member;
+package com.jitterted.mobreg.application.port;
 
-import com.jitterted.mobreg.application.port.Notifier;
 import com.jitterted.mobreg.domain.Ensemble;
 import com.jitterted.mobreg.domain.Member;
 

--- a/src/test/java/com/jitterted/mobreg/domain/EnsembleAcceptedMembersTest.java
+++ b/src/test/java/com/jitterted/mobreg/domain/EnsembleAcceptedMembersTest.java
@@ -23,7 +23,7 @@ public class EnsembleAcceptedMembersTest {
     @Test
     public void acceptMemberByIdWithEnsembleRemembersTheMember() throws Exception {
         Ensemble ensemble = EnsembleFactory.withStartTimeNow();
-        MemberId memberId = new TestMemberBuilder().buildAndSave().getId();
+        MemberId memberId = MemberId.of(123);
 
         ensemble.acceptedBy(memberId);
 


### PR DESCRIPTION
Added the ArchUnit dependency and a few tests that verify the Hexagonal Architecture rules I could think of.

In doing so, I (well, ArchUnit did) noticed that the rule _Domain must not depend on Application_ is violated in tests. Some test data builders and factories declared in the Application package are used in Domain tests. I refactored one of the tests as an example for fixing the violation.

For the sake of keeping the PR that introduces ArchUnit small I did not refactor further, but instead changed the test to only check production classes for now.